### PR TITLE
캠페인 / 소재 / 소재 실적 차트 추가

### DIFF
--- a/src/main/java/com/agencyplatformclonecoding/repository/DashboardQueryRepository.java
+++ b/src/main/java/com/agencyplatformclonecoding/repository/DashboardQueryRepository.java
@@ -265,4 +265,119 @@ public class DashboardQueryRepository {
 
         return results;
     }
+
+    // 캠페인 실적 차트
+    public List<DashboardStatisticsDto> chartQuery1(@Param("id") String clientId,
+                                                    @Param("startDate") LocalDate startDate,
+                                                    @Param("lastDate") LocalDate lastDate
+    ) {
+        List<DashboardStatisticsDto> results = jpaQueryFactory
+                .select(Projections.fields(DashboardStatisticsDto.class,
+                        performance.view.sum().as("view"),
+                        performance.click.sum().as("click"),
+                        performance.conversion.sum().as("conversion"),
+                        performance.purchase.sum().as("purchase"),
+                        performance.spend.sum().as("spend"),
+                        performance.createdAt.as("startDate")
+                ))
+                .from(performance)
+                .leftJoin(performance.creative, creative)
+                .leftJoin(creative.campaign, campaign)
+                .leftJoin(campaign.clientUser, clientUser)
+                .where(
+                        performance.createdAt.between(startDate, lastDate),
+                        clientUser.userId.eq(clientId),
+                        campaign.deleted.eq(false)
+                )
+                .groupBy(performance.createdAt)
+                .fetch();
+
+        for (DashboardStatisticsDto result : results) {
+            Long spend = result.getSpend();
+            Long view = result.getView();
+            Long click = result.getClick();
+            Long conversion = result.getConversion();
+            Long purchase = result.getPurchase();
+
+            result.setPerformanceIndicator(spend, view, click, conversion, purchase);
+        }
+
+        return results;
+    }
+
+
+    // 소재 실적 차트
+    public List<DashboardStatisticsDto> chartQuery2(@Param("id") Long campaignId,
+                                                    @Param("startDate") LocalDate startDate,
+                                                    @Param("lastDate") LocalDate lastDate
+    ) {
+        List<DashboardStatisticsDto> results = jpaQueryFactory
+                .select(Projections.fields(DashboardStatisticsDto.class,
+                        performance.view.sum().as("view"),
+                        performance.click.sum().as("click"),
+                        performance.conversion.sum().as("conversion"),
+                        performance.purchase.sum().as("purchase"),
+                        performance.spend.sum().as("spend"),
+                        performance.createdAt.as("startDate")
+                ))
+                .from(performance)
+                .leftJoin(performance.creative, creative)
+                .leftJoin(creative.campaign, campaign)
+                .where(
+                        performance.createdAt.between(startDate, lastDate),
+                        campaign.id.eq(campaignId),
+                        performance.creative.deleted.eq(false)
+                )
+                .groupBy(performance.createdAt)
+                .fetch();
+
+        for (DashboardStatisticsDto result : results) {
+            Long spend = result.getSpend();
+            Long view = result.getView();
+            Long click = result.getClick();
+            Long conversion = result.getConversion();
+            Long purchase = result.getPurchase();
+
+            result.setPerformanceIndicator(spend, view, click, conversion, purchase);
+        }
+
+        return results;
+    }
+
+
+    // 상세 실적 차트
+    public List<DashboardStatisticsDto> chartQuery3(@Param("id") Long creativeId,
+                                                    @Param("startDate") LocalDate startDate,
+                                                    @Param("lastDate") LocalDate lastDate
+    ) {
+        List<DashboardStatisticsDto> results = jpaQueryFactory
+                .select(Projections.fields(DashboardStatisticsDto.class,
+                        performance.view.as("view"),
+                        performance.click.as("click"),
+                        performance.conversion.as("conversion"),
+                        performance.purchase.as("purchase"),
+                        performance.spend.as("spend"),
+                        performance.createdAt.as("startDate")
+                ))
+                .from(performance)
+                .leftJoin(performance.creative, creative)
+                .where(
+                        performance.createdAt.between(startDate, lastDate),
+                        creative.id.eq(creativeId)
+                )
+                .groupBy(performance.createdAt)
+                .fetch();
+
+        for (DashboardStatisticsDto result : results) {
+            Long spend = result.getSpend();
+            Long view = result.getView();
+            Long click = result.getClick();
+            Long conversion = result.getConversion();
+            Long purchase = result.getPurchase();
+
+            result.setPerformanceIndicator(spend, view, click, conversion, purchase);
+        }
+
+        return results;
+    }
 }

--- a/src/main/java/com/agencyplatformclonecoding/service/DashboardService.java
+++ b/src/main/java/com/agencyplatformclonecoding/service/DashboardService.java
@@ -291,4 +291,64 @@ public class DashboardService {
 
         return resultPage;
     }
+
+    // 캠페인 실적 지표 차트 출력
+    @Transactional(readOnly = true)
+    public List<DashboardStatisticsDto> setChart1(LocalDate startDate, LocalDate lastDate, String clientId) {
+
+        LocalDate defaultLastDate = LocalDate.parse(LocalDate.now().minusDays(1)
+                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+        LocalDate startDateBeforeSevenDays = defaultLastDate.minusDays(6);
+        LocalDate startDateBeforeThirtyDays = defaultLastDate.minusDays(30);
+
+        if (lastDate == null) {
+            lastDate = defaultLastDate;
+        }
+
+        if (startDate == null) {
+            startDate = startDateBeforeThirtyDays;
+        }
+
+        return dashboardQueryRepository.chartQuery1(clientId, startDate, lastDate);
+    }
+
+    // 소재 실적 지표 차트 출력
+    @Transactional(readOnly = true)
+    public List<DashboardStatisticsDto> setChart2(LocalDate startDate, LocalDate lastDate, Long campaignId) {
+
+        LocalDate defaultLastDate = LocalDate.parse(LocalDate.now().minusDays(1)
+                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+        LocalDate startDateBeforeSevenDays = defaultLastDate.minusDays(6);
+        LocalDate startDateBeforeThirtyDays = defaultLastDate.minusDays(30);
+
+        if (lastDate == null) {
+            lastDate = defaultLastDate;
+        }
+
+        if (startDate == null) {
+            startDate = startDateBeforeThirtyDays;
+        }
+
+        return dashboardQueryRepository.chartQuery2(campaignId, startDate, lastDate);
+    }
+
+    // 상세 실적 지표 차트 출력
+    @Transactional(readOnly = true)
+    public List<DashboardStatisticsDto> setChart3(LocalDate startDate, LocalDate lastDate, Long creativeId) {
+
+        LocalDate defaultLastDate = LocalDate.parse(LocalDate.now().minusDays(1)
+                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+        LocalDate startDateBeforeSevenDays = defaultLastDate.minusDays(6);
+        LocalDate startDateBeforeThirtyDays = defaultLastDate.minusDays(30);
+
+        if (lastDate == null) {
+            lastDate = defaultLastDate;
+        }
+
+        if (startDate == null) {
+            startDate = startDateBeforeThirtyDays;
+        }
+
+        return dashboardQueryRepository.chartQuery3(creativeId, startDate, lastDate);
+    }
 }

--- a/src/main/java/com/agencyplatformclonecoding/service/ReportService.java
+++ b/src/main/java/com/agencyplatformclonecoding/service/ReportService.java
@@ -28,10 +28,10 @@ public class ReportService {
 
     private final StatisticsQueryRepository statisticsQueryRepository;
     private final DashboardQueryRepository dashboardQueryRepository;
-    private static final String[] PERFORMANCE_HEADER = {"날짜", "소재 ID", "키워드명", "입찰가", "노출수", "클릭수", "전환수", "구매액", "소진액", "클릭률", "전환률", "CPA", "ROAS"};
-    private static final String[] CREATIVE_HEADER = {"날짜", "소재 ID", "키워드명", "입찰가", "노출수", "클릭수", "전환수", "구매액", "소진액", "클릭률", "전환률", "CPA", "ROAS"};
-    private static final String[] CAMPAIGN_HEADER = {"날짜", "캠페인 ID", "캠페인명", "예산", "노출수", "클릭수", "전환수", "구매액", "소진액", "클릭률", "전환률", "CPA", "ROAS"};
-    private static final String[] CLIENT_HEADER_P = {"날짜", "광고주 ID", "광고주명", "업종", "노출수", "클릭수", "전환수", "구매액", "소진액", "클릭률", "전환률", "CPA", "ROAS"};
+    private static final String[] PERFORMANCE_HEADER = {"날짜", "소재 ID", "키워드명", "입찰가", "노출수", "클릭수", "전환수", "전환매출", "소진액", "클릭률", "전환률", "CPA", "ROAS"};
+    private static final String[] CREATIVE_HEADER = {"날짜", "소재 ID", "키워드명", "입찰가", "노출수", "클릭수", "전환수", "전환매출", "소진액", "클릭률", "전환률", "CPA", "ROAS"};
+    private static final String[] CAMPAIGN_HEADER = {"날짜", "캠페인 ID", "캠페인명", "예산", "노출수", "클릭수", "전환수", "전환매출", "소진액", "클릭률", "전환률", "CPA", "ROAS"};
+    private static final String[] CLIENT_HEADER_P = {"날짜", "광고주 ID", "광고주명", "업종", "노출수", "클릭수", "전환수", "전환매출", "소진액", "클릭률", "전환률", "CPA", "ROAS"};
     private static final String[] CLIENT_HEADER_S = {"날짜", "광고주 ID", "광고주명", "업종", "에이전트 ID", "소진액"};
 
 
@@ -852,7 +852,7 @@ public class ReportService {
             sheet.setColumnWidth(10, 11 * 256); // ROAS
 
             // header
-            final String[] header = {"기간", "업종", "노출수", "클릭수", "전환수", "구매액", "소진액", "클릭률", "전환률", "CPA", "ROAS"};
+            final String[] header = {"기간", "업종", "노출수", "클릭수", "전환수", "전환매출", "소진액", "클릭률", "전환률", "CPA", "ROAS"};
             Row row = sheet.createRow(0);
             for (int i = 0; i < header.length; i++) {
                 Cell cell = row.createCell(i);

--- a/src/main/resources/static/css/layout.css
+++ b/src/main/resources/static/css/layout.css
@@ -88,7 +88,7 @@ main {
 
 .date-form {
     display: flex !important;
-    width: 160px;
+    width: 140px;
     margin-right: 10px;
     margin-left: 0px;
 }
@@ -103,7 +103,7 @@ th, td {
 
 .stats-btn {
     width: fit-content;
-    margin-right: 10px;
+    margin-right: 5px;
 }
 
 .row.right {

--- a/src/main/resources/templates/dashboard/reference.html
+++ b/src/main/resources/templates/dashboard/reference.html
@@ -106,11 +106,11 @@
           <a class="stats-btn btn btn-primary" role="button" id="reference_dashboard">업종별 레퍼런스</a>
           <a class="stats-btn btn btn-primary" role="button" id="get-report">보고서 다운로드</a>
         </form>
-        <select name="performance" style="width: 90px; margin-left: 50px;">
+        <select id="performance" style="width: 90px; margin-left: 50px;">
           <option value="view">노출수</option>
-          <option value="click">노출수</option>
+          <option value="click">클릭수</option>
           <option value="conversion">전환수</option>
-          <option value="purchase">구매액</option>
+          <option value="purchase">전환매출</option>
           <option value="spend">소진액</option>
           <option value="CTR" selected>클릭률</option>
           <option value="CVR">전환률</option>
@@ -135,7 +135,7 @@
           <th class="view" style="width: 60px;"><a>노출수</a></th>
           <th class="click" style="width: 60px;"><a>클릭수</a></th>
           <th class="conversion" style="width: 60px;"><a>전환수</a></th>
-          <th class="purchase" style="width: 90px;"><a>구매액</a></th>
+          <th class="purchase" style="width: 90px;"><a>전환매출</a></th>
           <th class="spend" style="width: 90px;"><a>소진액</a></th>
           <th class="CTR" style="width: 60px;"><a>클릭률</a></th>
           <th class="CVR" style="width: 60px;"><a>전환률</a></th>
@@ -177,69 +177,148 @@
 
 <script type="text/javascript" th:inline="javascript">
     /*<![CDATA[*/
-    $(document).ready(function () {
-        var categoryList = [];
-        var performanceList = [];
-
-        var data = /*[[ ${results} ]]*/[];
-        for (var i = 0; i < data.length; i++) {
-            categoryList.push(data[i].category);
-            performanceList.push(data[i].ctr);
-        }
-        const ctx = document.getElementById('myChart').getContext('2d');
-        const chart = new Chart(ctx, {
-            type: 'bar', //chart 타입
-            data: {
-                labels: categoryList,
-                datasets: [{
-                    fill: false,
-                    data: performanceList,
-                    backgroundColor: [
-                        'rgb(95,192,153)',
-                    ],
-                    borderColor: [
-                        'rgba(125,134,173,0)',
-                    ],
-                    borderWidth: 1,
-                    barPercentage: 0.5
-                }]
-            },
-            options: {
-                plugins: {
-                    legend: {
-                        display: false
-                    },
+    var ctx = document.getElementById('myChart').getContext('2d');
+    var dayList = [];
+    var PerformanceList = [];
+    var data = /*[[ ${results} ]]*/[];
+    var config = {
+        type: 'bar',
+        data: {
+            labels: dayList,
+            datasets: [{
+                fill: false,
+                data: PerformanceList,
+                backgroundColor: [
+                    'rgb(95,192,153)',
+                ],
+                borderColor: [
+                    'rgba(125,134,173,0)',
+                ],
+                borderWidth: 1,
+                barPercentage: 0.5
+            }]
+        },
+        options: {
+            plugins: {
+                legend: {
+                    display: false
                 },
-                scales: {
-                    y: {
-                        grid: {
-                            drawOnChartArea: true,  //선 지우기
-                            drawTicks: false,   //축의 숫자 옆 눈금 지우기
-                            drawBorder: true,
-                            borderDash: [3, 3]	//y축 선 실선으로 길이 3,간격 3으로
-                        },
-                        ticks: {
-                            padding: 10,
-                            beginAtZero: true
-                        }
+            },
+            scales: {
+                y: {
+                    grid: {
+                        drawOnChartArea: true,  //선 지우기
+                        drawTicks: false,   //축의 숫자 옆 눈금 지우기
+                        drawBorder: true,
+                        borderDash: [3, 3]	//y축 선 실선으로 길이 3,간격 3으로
                     },
-                    x: {
-                        grid: {
-                            display: false,
-                            drawBorder: false,
-                            drawTicks: false
+                    ticks: {
+                        padding: 10,
+                        beginAtZero: true
+                    }
+                },
+                x: {
+                    grid: {
+                        display: false,
+                        drawBorder: false,
+                        drawTicks: false
+                    },
+                    ticks: {
+                        font: {
+                            size: 9
                         },
-                        ticks: {
-                            font: {
-                                size: 9
-                            },
-                            padding: 10
-                        }
+                        padding: 10
                     }
                 }
             }
-        });
+        }
+    };
+
+    // 차트 그리기
+
+    var myChart = new Chart(ctx, config);
+
+    // 초기 페이지 조회 시 작동
+    $(document).ready(function () {
+
+        var data = /*[[ ${results} ]]*/[];
+        for (var i = 0; i < data.length; i++) {
+            dayList.push(data[i].category);
+            PerformanceList.push(data[i].ctr);
+        }
+
+        myChart.update();
+
     });
+
+    $(function () {
+
+        $('#performance').on('change', function () { // 변경 감지
+
+            config.data.datasets.splice(0,1);
+
+            var data = /*[[ ${results} ]]*/[];
+            var newPerformanceList = [];
+            var value = this.value;
+
+            if (value == 'view') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].view);
+                }
+            } else if (value == 'click') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].click);
+                }
+            } else if (value == 'conversion') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].conversion);
+                }
+            } else if (value == 'purchase') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].purchase);
+                }
+            } else if (value == 'spend') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].spend);
+                }
+            } else if (value == 'CTR') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].ctr);
+                }
+            } else if (value == 'CVR') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].cvr);
+                }
+            } else if (value == 'CPA') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].cpa);
+                }
+            } else if (value == 'ROAS') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].roas);
+                }
+            }
+
+            var newDataSet = {
+                fill: false,
+                data: newPerformanceList,
+                backgroundColor: [
+                    'rgb(95,192,153)',
+                ],
+                borderColor: [
+                    'rgba(125,134,173,0)',
+                ],
+                borderWidth: 1,
+                barPercentage: 0.5
+            }
+
+            config.data.datasets.push(newDataSet);
+
+            myChart.update();
+        });
+
+    });
+
     /*]]>*/
 
 </script>

--- a/src/main/resources/templates/manage/campaign.html
+++ b/src/main/resources/templates/manage/campaign.html
@@ -6,7 +6,8 @@
   <meta name="author" content="mrcocoball">
   <title>캠페인 관리</title>
 
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet"
+        integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
 </head>
 
 <body>
@@ -68,7 +69,9 @@
   </div>
 
   <div class="container">
-    <nav style="--bs-breadcrumb-divider: url(&#34;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8'%3E%3Cpath d='M2.5 0L1 1.5 3.5 4 1 6.5 2.5 8l4-4-4-4z' fill='%236c757d'/%3E%3C/svg%3E&#34;);" aria-label="breadcrumb">
+    <nav
+        style="--bs-breadcrumb-divider: url(&#34;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8'%3E%3Cpath d='M2.5 0L1 1.5 3.5 4 1 6.5 2.5 8l4-4-4-4z' fill='%236c757d'/%3E%3C/svg%3E&#34;);"
+        aria-label="breadcrumb">
       <ol class="breadcrumb">
         <li class="breadcrumb-item"><a href="/manage">광고 관리</a></li>
         <li class="breadcrumb-item active" aria-current="page">캠페인 관리</li>
@@ -80,18 +83,33 @@
       <div class="create-btn d-grid gap-2 justify-content-md">
         <form id="statistics-date-form" method="get">
           <div class="date-form">
-            <input type="date" class="form-control" id="start-date" name="startDate", min="2020-01-01" />
+            <input type="date" class="form-control" id="start-date" name="startDate" , min="2020-01-01"/>
           </div>
           <div class="date-form">
-            <input type="date" class="form-control" id="last-date" name="lastDate" />
+            <input type="date" class="form-control" id="last-date" name="lastDate"/>
           </div>
-            <button type="submit" class="stats-btn btn btn-primary" role="button" id="statistics_type_custom">통계 확인</button>
+          <button type="submit" class="stats-btn btn btn-primary" role="button" id="statistics_type_custom">통계 확인
+          </button>
         </form>
-        <a class="stats-btn btn btn-primary" role="button" id="statistics_type_week">최근 7일간 통계</a>
-        <a class="stats-btn btn btn-primary" role="button" id="statistics_type_month">최근 30일간 통계</a>
+        <a class="stats-btn btn btn-primary" role="button" id="statistics_type_week">최근 7일</a>
+        <a class="stats-btn btn btn-primary" role="button" id="statistics_type_month">최근 30일</a>
         <a class="stats-btn btn btn-primary" role="button" id="get-report">실적 보고서</a>
         <a class="btn btn-primary me-md-2" role="button" id="create-campaign">캠페인 생성</a>
+        <select id="performance">
+          <option value="view">노출수</option>
+          <option value="click">클릭수</option>
+          <option value="conversion">전환수</option>
+          <option value="purchase">전환매출</option>
+          <option value="spend" selected>소진액</option>
+          <option value="CTR">클릭률</option>
+          <option value="CVR">전환률</option>
+          <option value="CPA">CPA</option>
+          <option value="ROAS">ROAS</option>
+        </select>
       </div>
+
+      <canvas id="myChart" height="175" width="600"></canvas>
+
       <table class="table" id="client-info">
         <thead>
         <tr>
@@ -117,7 +135,7 @@
           <th class="view" style="width: 75px;"><a>총 노출수</a></th>
           <th class="click" style="width: 75px;"><a>총 클릭수</a></th>
           <th class="conversion" style="width: 75px;"><a>총 전환수</a></th>
-          <th class="purchase" style="width: 100px;"><a>총 구매액</a></th>
+          <th class="purchase" style="width: 100px;"><a>총 전환매출</a></th>
           <th class="spend" style="width: 80px;"><a>총 소진액</a></th>
           <th class="CTR" style="width: 75px;"><a>클릭률</a></th>
           <th class="CVR" style="width: 75px;"><a>전환률</a></th>
@@ -150,7 +168,7 @@
           <th class="view" style="width: 75px;"><a>노출수</a></th>
           <th class="click" style="width: 75px;"><a>클릭수</a></th>
           <th class="conversion" style="width: 75px;"><a>전환수</a></th>
-          <th class="purchase" style="width: 100px;"><a>구매액</a></th>
+          <th class="purchase" style="width: 100px;"><a>전환매출</a></th>
           <th class="spend" style="width: 90px;"><a>소진액</a></th>
           <th class="CTR" style="width: 75px;"><a>클릭률</a></th>
           <th class="CVR" style="width: 75px;"><a>전환률</a></th>
@@ -253,5 +271,158 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-A3rJD856KowSb7dwlZdYEkO39Gagi7vIsF0jrRAoQmDKKtQBHUuLZ9AsSv4jD4Xa"
         crossorigin="anonymous"></script>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.6.1.js"
+        integrity="sha256-3zlB5s2uwoUzrXK3BT7AX3FyvojsraNFxCc2vC/7pNI="
+        crossorigin="anonymous"></script>
+
+<script type="text/javascript" th:inline="javascript">
+    /*<![CDATA[*/
+    var ctx = document.getElementById('myChart').getContext('2d');
+    var dayList = [];
+    var performanceList = [];
+    var data = /*[[ ${chart} ]]*/[];
+    var config = {
+        type: 'line',
+        data: {
+            labels: dayList,
+            datasets: [{
+                fill: false,
+                data: performanceList,
+                backgroundColor: [
+                    'rgb(95,192,153)',
+                ],
+                borderColor: [
+                    'rgba(125,134,173,1)',
+                ],
+                borderWidth: 1,
+                barPercentage: 0.5
+            }]
+        },
+        options: {
+            plugins: {
+                legend: {
+                    display: false
+                },
+            },
+            scales: {
+                y: {
+                    grid: {
+                        drawOnChartArea: true,  //선 지우기
+                        drawTicks: false,   //축의 숫자 옆 눈금 지우기
+                        drawBorder: true,
+                        borderDash: [3, 3]	//y축 선 실선으로 길이 3,간격 3으로
+                    },
+                    ticks: {
+                        padding: 10,
+                        beginAtZero: true
+                    }
+                },
+                x: {
+                    grid: {
+                        display: false,
+                        drawBorder: false,
+                        drawTicks: false
+                    },
+                    ticks: {
+                        font: {
+                            size: 9
+                        },
+                        padding: 10
+                    }
+                }
+            }
+        }
+    };
+
+    // 차트 그리기
+
+    var myChart = new Chart(ctx, config);
+
+    // 초기 페이지 조회 시 작동
+    $(document).ready(function () {
+
+        var data = /*[[ ${chart} ]]*/[];
+        for (var i = 0; i < data.length; i++) {
+            dayList.push(data[i].startDate);
+            performanceList.push(data[i].spend);
+        }
+
+        myChart.update();
+
+    });
+
+    $(function () {
+
+        $('#performance').on('change', function () { // 변경 감지
+
+            config.data.datasets.splice(0,1);
+
+            var data = /*[[ ${chart} ]]*/[];
+            var newPerformanceList = [];
+            var value = this.value;
+
+            if (value == 'view') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].view);
+                }
+            } else if (value == 'click') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].click);
+                }
+            } else if (value == 'conversion') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].conversion);
+                }
+            } else if (value == 'purchase') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].purchase);
+                }
+            } else if (value == 'spend') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].spend);
+                }
+            } else if (value == 'CTR') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].ctr);
+                }
+            } else if (value == 'CVR') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].cvr);
+                }
+            } else if (value == 'CPA') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].cpa);
+                }
+            } else if (value == 'ROAS') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].roas);
+                }
+            }
+
+            var newDataSet = {
+                fill: false,
+                data: newPerformanceList,
+                backgroundColor: [
+                    'rgb(95,192,153)',
+                ],
+                borderColor: [
+                    'rgba(125,134,173,1)',
+                ],
+                borderWidth: 1,
+                barPercentage: 0.5
+            }
+
+            config.data.datasets.push(newDataSet);
+
+            myChart.update();
+        });
+
+    });
+
+    /*]]>*/
+
+</script>
 
 </body>

--- a/src/main/resources/templates/manage/creative.html
+++ b/src/main/resources/templates/manage/creative.html
@@ -93,11 +93,25 @@
           </div>
           <button type="submit" class="stats-btn btn btn-primary" role="button" id="statistics_type_custom">통계 확인</button>
         </form>
-        <a class="stats-btn btn btn-primary" role="button" id="statistics_type_week">최근 7일간 통계</a>
-        <a class="stats-btn btn btn-primary" role="button" id="statistics_type_month">최근 30일간 통계</a>
+        <a class="stats-btn btn btn-primary" role="button" id="statistics_type_week">최근 7일</a>
+        <a class="stats-btn btn btn-primary" role="button" id="statistics_type_month">최근 30일</a>
         <a class="stats-btn btn btn-primary" role="button" id="get-report">실적 보고서</a>
         <a class="btn btn-primary me-md-2" role="button" id="create-creative">소재 생성</a>
+        <select id="performance">
+          <option value="view">노출수</option>
+          <option value="click">클릭수</option>
+          <option value="conversion">전환수</option>
+          <option value="purchase">전환매출</option>
+          <option value="spend" selected>소진액</option>
+          <option value="CTR">클릭률</option>
+          <option value="CVR">전환률</option>
+          <option value="CPA">CPA</option>
+          <option value="ROAS">ROAS</option>
+        </select>
       </div>
+
+      <canvas id="myChart" height="175" width="600"></canvas>
+
       <table class="table" id="statistics-info">
         <thead>
         <tr>
@@ -105,7 +119,7 @@
           <th class="view" style="width: 75px;"><a>총 노출수</a></th>
           <th class="click" style="width: 75px;"><a>총 클릭수</a></th>
           <th class="conversion" style="width: 75px;"><a>총 전환수</a></th>
-          <th class="purchase" style="width: 100px;"><a>총 구매액</a></th>
+          <th class="purchase" style="width: 100px;"><a>총 전환매출</a></th>
           <th class="spend" style="width: 80px;"><a>총 소진액</a></th>
           <th class="CTR" style="width: 75px;"><a>클릭률</a></th>
           <th class="CVR" style="width: 75px;"><a>전환률</a></th>
@@ -138,7 +152,7 @@
           <th class="view" style="width: 75px;"><a>노출수</a></th>
           <th class="click" style="width: 75px;"><a>클릭수</a></th>
           <th class="conversion" style="width: 75px;"><a>전환수</a></th>
-          <th class="purchase" style="width: 100px;"><a>구매액</a></th>
+          <th class="purchase" style="width: 100px;"><a>전환매출</a></th>
           <th class="spend" style="width: 90px;"><a>소진액</a></th>
           <th class="CTR" style="width: 75px;"><a>클릭률</a></th>
           <th class="CVR" style="width: 75px;"><a>전환률</a></th>
@@ -229,5 +243,158 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-A3rJD856KowSb7dwlZdYEkO39Gagi7vIsF0jrRAoQmDKKtQBHUuLZ9AsSv4jD4Xa"
         crossorigin="anonymous"></script>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.6.1.js"
+        integrity="sha256-3zlB5s2uwoUzrXK3BT7AX3FyvojsraNFxCc2vC/7pNI="
+        crossorigin="anonymous"></script>
+
+<script type="text/javascript" th:inline="javascript">
+    /*<![CDATA[*/
+    var ctx = document.getElementById('myChart').getContext('2d');
+    var dayList = [];
+    var performanceList = [];
+    var data = /*[[ ${chart} ]]*/[];
+    var config = {
+        type: 'line',
+        data: {
+            labels: dayList,
+            datasets: [{
+                fill: false,
+                data: performanceList,
+                backgroundColor: [
+                    'rgb(95,192,153)',
+                ],
+                borderColor: [
+                    'rgba(125,134,173,1)',
+                ],
+                borderWidth: 1,
+                barPercentage: 0.5
+            }]
+        },
+        options: {
+            plugins: {
+                legend: {
+                    display: false
+                },
+            },
+            scales: {
+                y: {
+                    grid: {
+                        drawOnChartArea: true,  //선 지우기
+                        drawTicks: false,   //축의 숫자 옆 눈금 지우기
+                        drawBorder: true,
+                        borderDash: [3, 3]	//y축 선 실선으로 길이 3,간격 3으로
+                    },
+                    ticks: {
+                        padding: 10,
+                        beginAtZero: true
+                    }
+                },
+                x: {
+                    grid: {
+                        display: false,
+                        drawBorder: false,
+                        drawTicks: false
+                    },
+                    ticks: {
+                        font: {
+                            size: 9
+                        },
+                        padding: 10
+                    }
+                }
+            }
+        }
+    };
+
+    // 차트 그리기
+
+    var myChart = new Chart(ctx, config);
+
+    // 초기 페이지 조회 시 작동
+    $(document).ready(function () {
+
+        var data = /*[[ ${chart} ]]*/[];
+        for (var i = 0; i < data.length; i++) {
+            dayList.push(data[i].startDate);
+            performanceList.push(data[i].spend);
+        }
+
+        myChart.update();
+
+    });
+
+    $(function () {
+
+        $('#performance').on('change', function () { // 변경 감지
+
+            config.data.datasets.splice(0,1);
+
+            var data = /*[[ ${chart} ]]*/[];
+            var newPerformanceList = [];
+            var value = this.value;
+
+            if (value == 'view') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].view);
+                }
+            } else if (value == 'click') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].click);
+                }
+            } else if (value == 'conversion') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].conversion);
+                }
+            } else if (value == 'purchase') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].purchase);
+                }
+            } else if (value == 'spend') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].spend);
+                }
+            } else if (value == 'CTR') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].ctr);
+                }
+            } else if (value == 'CVR') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].cvr);
+                }
+            } else if (value == 'CPA') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].cpa);
+                }
+            } else if (value == 'ROAS') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].roas);
+                }
+            }
+
+            var newDataSet = {
+                fill: false,
+                data: newPerformanceList,
+                backgroundColor: [
+                    'rgb(95,192,153)',
+                ],
+                borderColor: [
+                    'rgba(125,134,173,1)',
+                ],
+                borderWidth: 1,
+                barPercentage: 0.5
+            }
+
+            config.data.datasets.push(newDataSet);
+
+            myChart.update();
+        });
+
+    });
+
+    /*]]>*/
+
+</script>
 
 </body>

--- a/src/main/resources/templates/manage/performance.html
+++ b/src/main/resources/templates/manage/performance.html
@@ -94,10 +94,24 @@
           </div>
           <button type="submit" class="stats-btn btn btn-primary" role="button" id="statistics_type_custom">통계 확인</button>
         </form>
-        <a class="stats-btn btn btn-primary" role="button" id="statistics_type_week">최근 7일간 통계</a>
-        <a class="stats-btn btn btn-primary" role="button" id="statistics_type_month">최근 30일간 통계</a>
+        <a class="stats-btn btn btn-primary" role="button" id="statistics_type_week">최근 7일</a>
+        <a class="stats-btn btn btn-primary" role="button" id="statistics_type_month">최근 30일</a>
         <a class="stats-btn btn btn-primary" role="button" id="get-report">실적 보고서</a>
+        <select id="performance">
+          <option value="view">노출수</option>
+          <option value="click">클릭수</option>
+          <option value="conversion">전환수</option>
+          <option value="purchase">전환매출</option>
+          <option value="spend" selected>소진액</option>
+          <option value="CTR">클릭률</option>
+          <option value="CVR">전환률</option>
+          <option value="CPA">CPA</option>
+          <option value="ROAS">ROAS</option>
+        </select>
       </div>
+
+      <canvas id="myChart" height="175" width="600"></canvas>
+
       <table class="table" id="creative-info">
         <thead>
         <tr>
@@ -129,7 +143,7 @@
           <th class="view" style="width: 75px;"><a>총 노출수</a></th>
           <th class="click" style="width: 75px;"><a>총 클릭수</a></th>
           <th class="conversion" style="width: 75px;"><a>총 전환수</a></th>
-          <th class="purchase" style="width: 100px;"><a>총 구매액</a></th>
+          <th class="purchase" style="width: 100px;"><a>총 전환매출</a></th>
           <th class="spend" style="width: 80px;"><a>총 소진액</a></th>
           <th class="CTR" style="width: 75px;"><a>클릭률</a></th>
           <th class="CVR" style="width: 75px;"><a>전환률</a></th>
@@ -159,7 +173,7 @@
           <th class="view" style="width: 75px;"><a>노출수</a></th>
           <th class="click" style="width: 75px;"><a>클릭수</a></th>
           <th class="conversion" style="width: 75px;"><a>전환수</a></th>
-          <th class="purchase" style="width: 150px;"><a>구매액</a></th>
+          <th class="purchase" style="width: 150px;"><a>전환매출</a></th>
           <th class="spend" style="width: 125px;"><a>소진액</a></th>
           <th class="CTR" style="width: 75px;"><a>클릭률</a></th>
           <th class="CVR" style="width: 75px;"><a>전환률</a></th>
@@ -212,5 +226,158 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-A3rJD856KowSb7dwlZdYEkO39Gagi7vIsF0jrRAoQmDKKtQBHUuLZ9AsSv4jD4Xa"
         crossorigin="anonymous"></script>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.6.1.js"
+        integrity="sha256-3zlB5s2uwoUzrXK3BT7AX3FyvojsraNFxCc2vC/7pNI="
+        crossorigin="anonymous"></script>
+
+<script type="text/javascript" th:inline="javascript">
+    /*<![CDATA[*/
+    var ctx = document.getElementById('myChart').getContext('2d');
+    var dayList = [];
+    var performanceList = [];
+    var data = /*[[ ${chart} ]]*/[];
+    var config = {
+        type: 'line',
+        data: {
+            labels: dayList,
+            datasets: [{
+                fill: false,
+                data: performanceList,
+                backgroundColor: [
+                    'rgb(95,192,153)',
+                ],
+                borderColor: [
+                    'rgba(125,134,173,1)',
+                ],
+                borderWidth: 1,
+                barPercentage: 0.5
+            }]
+        },
+        options: {
+            plugins: {
+                legend: {
+                    display: false
+                },
+            },
+            scales: {
+                y: {
+                    grid: {
+                        drawOnChartArea: true,  //선 지우기
+                        drawTicks: false,   //축의 숫자 옆 눈금 지우기
+                        drawBorder: true,
+                        borderDash: [3, 3]	//y축 선 실선으로 길이 3,간격 3으로
+                    },
+                    ticks: {
+                        padding: 10,
+                        beginAtZero: true
+                    }
+                },
+                x: {
+                    grid: {
+                        display: false,
+                        drawBorder: false,
+                        drawTicks: false
+                    },
+                    ticks: {
+                        font: {
+                            size: 9
+                        },
+                        padding: 10
+                    }
+                }
+            }
+        }
+    };
+
+    // 차트 그리기
+
+    var myChart = new Chart(ctx, config);
+
+    // 초기 페이지 조회 시 작동
+    $(document).ready(function () {
+
+        var data = /*[[ ${chart} ]]*/[];
+        for (var i = 0; i < data.length; i++) {
+            dayList.push(data[i].startDate);
+            performanceList.push(data[i].spend);
+        }
+
+        myChart.update();
+
+    });
+
+    $(function () {
+
+        $('#performance').on('change', function () { // 변경 감지
+
+            config.data.datasets.splice(0,1);
+
+            var data = /*[[ ${chart} ]]*/[];
+            var newPerformanceList = [];
+            var value = this.value;
+
+            if (value == 'view') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].view);
+                }
+            } else if (value == 'click') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].click);
+                }
+            } else if (value == 'conversion') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].conversion);
+                }
+            } else if (value == 'purchase') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].purchase);
+                }
+            } else if (value == 'spend') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].spend);
+                }
+            } else if (value == 'CTR') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].ctr);
+                }
+            } else if (value == 'CVR') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].cvr);
+                }
+            } else if (value == 'CPA') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].cpa);
+                }
+            } else if (value == 'ROAS') {
+                for (var i = 0; i < data.length; i++) {
+                    newPerformanceList.push(data[i].roas);
+                }
+            }
+
+            var newDataSet = {
+                fill: false,
+                data: newPerformanceList,
+                backgroundColor: [
+                    'rgb(95,192,153)',
+                ],
+                borderColor: [
+                    'rgba(125,134,173,1)',
+                ],
+                borderWidth: 1,
+                barPercentage: 0.5
+            }
+
+            config.data.datasets.push(newDataSet);
+
+            myChart.update();
+        });
+
+    });
+
+    /*]]>*/
+
+</script>
 
 </body>


### PR DESCRIPTION
캠페인 / 소재 / 소재 실적 페이지에도 특정 지표에 대한 차트를 띄울 수 있게 수정한다

* [x] 캠페인 차트 (캠페인 및 기간별 정렬)
* [x] 소재 차트 (소재 및 기간별 정렬)
* [x] 실적 차트 (기간별 정렬)
* [x] 대시보드 관련 메소드 이름 변경
* [x] '구매액' -> '전환 매출액' 로 변경

This closes #138 